### PR TITLE
Remove 'should' from spec desc string

### DIFF
--- a/snippets/jasmine.snippets
+++ b/snippets/jasmine.snippets
@@ -18,7 +18,7 @@ snippet after
 
 # a spec is called with it()
 snippet it
-	it('should ${1:...}', function(){
+	it('${1:...}', function(){
 		expect(${2:condition}).toEqual(${3});
 	});
 


### PR DESCRIPTION
A suggestion from [Better Specs](http://betterspecs.org/#should)
